### PR TITLE
Update from `ERC20` to `TRC20`

### DIFF
--- a/ITRC20.sol
+++ b/ITRC20.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.0;
 
 /**
- * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
- * the optional functions; to access them see {ERC20Detailed}.
+ * @dev Interface of the TRC20 standard as defined in the TIP. Does not include
+ * the optional functions; to access them see {TRC20Detailed}.
  */
-interface IERC20 {
+interface ITRC20 {
     /**
      * @dev Returns the amount of tokens in existence.
      */

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # TRC20-Contract-Template
+
+# TRC-20
+TRC-20 is a technical standard used for smart contracts on the TRON blockchain for implementing tokens with the TRON Virtual Machine (TVM). It is fully compatible to ERC-20.

--- a/TRC20.sol
+++ b/TRC20.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.0;
 
-import "./IERC20.sol";
+import "./ITRC20.sol";
 import "./SafeMath.sol";
 
 /**
- * @dev Implementation of the {IERC20} interface.
+ * @dev Implementation of the {ITRC20} interface.
  *
  * This implementation is agnostic to the way tokens are created. This means
  * that a supply mechanism has to be added in a derived contract using {_mint}.
@@ -16,18 +16,18 @@ import "./SafeMath.sol";
  *
  * We have followed general OpenZeppelin guidelines: functions revert instead
  * of returning `false` on failure. This behavior is nonetheless conventional
- * and does not conflict with the expectations of ERC20 applications.
+ * and does not conflict with the expectations of TRC20 applications.
  *
  * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
  * This allows applications to reconstruct the allowance for all accounts just
- * by listening to said events. Other implementations of the EIP may not emit
+ * by listening to said events. Other implementations of the TIP may not emit
  * these events, as it isn't required by the specification.
  *
  * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
  * functions have been added to mitigate the well-known issues around setting
- * allowances. See {IERC20-approve}.
+ * allowances. See {ITRC20-approve}.
  */
-contract ERC20 is IERC20 {
+contract TRC20 is ITRC20 {
     using SafeMath for uint256;
 
     mapping (address => uint256) private _balances;
@@ -37,21 +37,21 @@ contract ERC20 is IERC20 {
     uint256 private _totalSupply;
 
     /**
-     * @dev See {IERC20-totalSupply}.
+     * @dev See {ITRC20-totalSupply}.
      */
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
     }
 
     /**
-     * @dev See {IERC20-balanceOf}.
+     * @dev See {ITRC20-balanceOf}.
      */
     function balanceOf(address account) public view returns (uint256) {
         return _balances[account];
     }
 
     /**
-     * @dev See {IERC20-transfer}.
+     * @dev See {ITRC20-transfer}.
      *
      * Requirements:
      *
@@ -64,14 +64,14 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev See {IERC20-allowance}.
+     * @dev See {ITRC20-allowance}.
      */
     function allowance(address owner, address spender) public view returns (uint256) {
         return _allowances[owner][spender];
     }
 
     /**
-     * @dev See {IERC20-approve}.
+     * @dev See {ITRC20-approve}.
      *
      * Requirements:
      *
@@ -83,10 +83,10 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev See {IERC20-transferFrom}.
+     * @dev See {ITRC20-transferFrom}.
      *
      * Emits an {Approval} event indicating the updated allowance. This is not
-     * required by the EIP. See the note at the beginning of {ERC20};
+     * required by the TIP. See the note at the beginning of {TRC20};
      *
      * Requirements:
      * - `sender` and `recipient` cannot be the zero address.
@@ -104,7 +104,7 @@ contract ERC20 is IERC20 {
      * @dev Atomically increases the allowance granted to `spender` by the caller.
      *
      * This is an alternative to {approve} that can be used as a mitigation for
-     * problems described in {IERC20-approve}.
+     * problems described in {ITRC20-approve}.
      *
      * Emits an {Approval} event indicating the updated allowance.
      *
@@ -121,7 +121,7 @@ contract ERC20 is IERC20 {
      * @dev Atomically decreases the allowance granted to `spender` by the caller.
      *
      * This is an alternative to {approve} that can be used as a mitigation for
-     * problems described in {IERC20-approve}.
+     * problems described in {ITRC20-approve}.
      *
      * Emits an {Approval} event indicating the updated allowance.
      *
@@ -151,8 +151,8 @@ contract ERC20 is IERC20 {
      * - `sender` must have a balance of at least `amount`.
      */
     function _transfer(address sender, address recipient, uint256 amount) internal {
-        require(sender != address(0), "ERC20: transfer from the zero address");
-        require(recipient != address(0), "ERC20: transfer to the zero address");
+        require(sender != address(0), "TRC20: transfer from the zero address");
+        require(recipient != address(0), "TRC20: transfer to the zero address");
 
         _balances[sender] = _balances[sender].sub(amount);
         _balances[recipient] = _balances[recipient].add(amount);
@@ -169,7 +169,7 @@ contract ERC20 is IERC20 {
      * - `to` cannot be the zero address.
      */
     function _mint(address account, uint256 amount) internal {
-        require(account != address(0), "ERC20: mint to the zero address");
+        require(account != address(0), "TRC20: mint to the zero address");
 
         _totalSupply = _totalSupply.add(amount);
         _balances[account] = _balances[account].add(amount);
@@ -188,7 +188,7 @@ contract ERC20 is IERC20 {
      * - `account` must have at least `amount` tokens.
      */
     function _burn(address account, uint256 value) internal {
-        require(account != address(0), "ERC20: burn from the zero address");
+        require(account != address(0), "TRC20: burn from the zero address");
 
         _totalSupply = _totalSupply.sub(value);
         _balances[account] = _balances[account].sub(value);
@@ -209,8 +209,8 @@ contract ERC20 is IERC20 {
      * - `spender` cannot be the zero address.
      */
     function _approve(address owner, address spender, uint256 value) internal {
-        require(owner != address(0), "ERC20: approve from the zero address");
-        require(spender != address(0), "ERC20: approve to the zero address");
+        require(owner != address(0), "TRC20: approve from the zero address");
+        require(spender != address(0), "TRC20: approve to the zero address");
 
         _allowances[owner][spender] = value;
         emit Approval(owner, spender, value);

--- a/TRC20Detailed.sol
+++ b/TRC20Detailed.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 import "./ITRC20.sol";
 
 /**
- * @dev Optional functions from the ERC20 standard.
+ * @dev Optional functions from the TRC20 standard.
  */
 contract TRC20Detailed is ITRC20 {
     string private _name;

--- a/TRC20Detailed.sol
+++ b/TRC20Detailed.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.5.0;
 
-import "./IERC20.sol";
+import "./ITRC20.sol";
 
 /**
  * @dev Optional functions from the ERC20 standard.
  */
-contract ERC20Detailed is IERC20 {
+contract TRC20Detailed is ITRC20 {
     string private _name;
     string private _symbol;
     uint8 private _decimals;
@@ -46,7 +46,7 @@ contract ERC20Detailed is IERC20 {
      *
      * NOTE: This information is only used for _display_ purposes: it in
      * no way affects any of the arithmetic of the contract, including
-     * {IERC20-balanceOf} and {IERC20-transfer}.
+     * {ITRC20-balanceOf} and {ITRC20-transfer}.
      */
     function decimals() public view returns (uint8) {
         return _decimals;

--- a/Token.sol
+++ b/Token.sol
@@ -2,21 +2,21 @@
 // Enable optimization
 pragma solidity ^0.5.0;
 
-import "./ERC20.sol";
-import "./ERC20Detailed.sol";
+import "./TRC20.sol";
+import "./TRC20Detailed.sol";
 
 /**
  * @title SimpleToken
- * @dev Very simple ERC20 Token example, where all tokens are pre-assigned to the creator.
+ * @dev Very simple TRC20 Token example, where all tokens are pre-assigned to the creator.
  * Note they can later distribute these tokens as they wish using `transfer` and other
- * `ERC20` functions.
+ * `TRC20` functions.
  */
-contract Token is ERC20, ERC20Detailed {
+contract Token is TRC20, TRC20Detailed {
 
     /**
      * @dev Constructor that gives msg.sender all of existing tokens.
      */
-    constructor () public ERC20Detailed("YourTokenName", "YTN", 18) {
+    constructor () public TRC20Detailed("YourTokenName", "YTN", 18) {
         _mint(msg.sender, 10000000000 * (10 ** uint256(decimals())));
     }
 }


### PR DESCRIPTION
### **Updated from `ERC20` to `TRC20` standards for `Tron Virtual Machine (TVM)`.**

The changes made in this pull request are as follows :

> Created & Updated `README.md` file.

> Renamed & Updated  `IERC20.sol` to `ITRC20.sol`.

> Renamed & Updated  `ERC20Detailed.sol` to `TRC20Detailed.sol`.

> Renamed & Updated  `ERC20.sol` to `TRC20.sol`.

> Updated `Token.sol` for changes regarding `TRC20`.